### PR TITLE
Feature/pr 20

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -67,3 +67,31 @@
 | bgpNeighborUptime  | Gauge  | uptime of the bgp neighbor  | 
 | bgpNeighborReceivedPrefix  | Gauge  | total number of prefixes received from the neighbor  | 
 | bgpNeighborSentPrefix  | Gauge  | total number of prefixes advertised to the neighbor  | 
+
+
+## Appliances Flows
+
+| Name  | Type  | Description  |
+| ------------ | ------------ | ------------ |
+| activeTotalFlows  | Gauge  | number of active flows  | 
+| activeStaleFlows  | Gauge  | number of active stale flows  | 
+| activeInconsistentFlows  | Gauge  | number of active inconsistent flows  | 
+| activeFlowsWithIssues  | Gauge  | number of active flows with issues  | 
+| activeFlowsOptimized  | Gauge  | number of active optimized flows  | 
+| activeFlowsWithIgnores  | Gauge  | no description in swagger  | 
+| activeFlowsPassthrough  | Gauge  | number of active passthrough flows  | 
+| activeFlowsManagement  | Gauge  | number of active management flows  | 
+| activeFlowsAsymmetric  | Gauge  | number of active asymmetric flows  | 
+| activeFlowsRouteDropped  | Gauge  | number of active flows dropped due to route  | 
+| activeFlowsFirewallDropped  | Gauge  | number of active flows dropped due to firewall  | 
+| inactiveTotalFlows  | Gauge  | number of inactive flows  | 
+| inactiveStaleFlows  | Gauge  | number of inactive stale flows  | 
+| inactiveInconsistentFlows  | Gauge  | number of inactive inconsistent flows  | 
+| inactiveFlowsWithIssues  | Gauge  | number of inactive flows with issues  | 
+| inactiveFlowsOptimized  | Gauge  | number of inactive optimized flows  | 
+| inactiveFlowsWithIgnores  | Gauge  | no description in swagger  | 
+| inactiveFlowsPassthrough  | Gauge  | number of inactive passthrough flows  | 
+| inactiveFlowsManagement  | Gauge  | number of inactive management flows  | 
+| inactiveFlowsAsymmetric  | Gauge  | number of inactive asymmetric flows  | 
+| inactiveFlowsRouteDropped  | Gauge  | number of inactive flows dropped due to route  | 
+| inactiveFlowsFirewallDropped  | Gauge  | number of inactive flows dropped due to firewall  | 

--- a/silverpeak_exporter/metrics.py
+++ b/silverpeak_exporter/metrics.py
@@ -69,3 +69,32 @@ bgpNeighborStateStr = Info('bgpNeighborStateStr', 'state of bgp neighbor in stri
 bgpNeighborUptime = Gauge('bgpNeighborUptime', 'uptime of the bgp neighbor',['applianceName','peer_ip'])
 bgpNeighborReceivedPrefix = Gauge('bgpNeighborReceivedPrefix', 'total number of prefixes received from the neighbor',['applianceName','peer_ip'])
 bgpNeighborSentPrefix = Gauge('bgpNeighborSentPrefix', 'total number of prefixes advertised to the neighbor',['applianceName','peer_ip'])
+
+
+
+#---------#---------#---------#---------#---------#
+# Flows Metrics
+#---------#---------#---------#---------#---------#
+
+activeTotalFlows = Gauge('activeTotalFlows', 'number of active flows',['applianceName',])
+activeStaleFlows = Gauge('activeStaleFlows', 'number of active stale flows',['applianceName',])
+activeInconsistentFlows = Gauge('activeInconsistentFlows', 'number of active inconsistent flows',['applianceName',])
+activeFlowsWithIssues = Gauge('activeFlowsWithIssues', 'number of active flows with issues',['applianceName',])
+activeFlowsOptimized = Gauge('activeFlowsOptimized', 'number of active optimized flows',['applianceName',])
+activeFlowsWithIgnores = Gauge('activeFlowsWithIgnores', 'no description in swagger',['applianceName',])
+activeFlowsPassthrough = Gauge('activeFlowsPassthrough', 'number of active passthrough flows',['applianceName',])
+activeFlowsManagement = Gauge('activeFlowsManagement', 'number of active management flows',['applianceName',])
+activeFlowsAsymmetric = Gauge('activeFlowsAsymmetric', 'number of active asymmetric flows',['applianceName',])
+activeFlowsRouteDropped = Gauge('activeFlowsRouteDropped', 'number of active flows dropped due to route',['applianceName',])
+activeFlowsFirewallDropped = Gauge('activeFlowsFirewallDropped', 'number of active flows dropped due to firewall',['applianceName',])
+inactiveTotalFlows = Gauge('inactiveTotalFlows', 'number of inactive flows',['applianceName',])
+inactiveStaleFlows = Gauge('inactiveStaleFlows', 'number of inactive stale flows',['applianceName',])
+inactiveInconsistentFlows = Gauge('inactiveInconsistentFlows', 'number of inactive inconsistent flows',['applianceName',])
+inactiveFlowsWithIssues = Gauge('inactiveFlowsWithIssues', 'number of inactive flows with issues',['applianceName',])
+inactiveFlowsOptimized = Gauge('inactiveFlowsOptimized', 'number of inactive optimized flows',['applianceName',])
+inactiveFlowsWithIgnores = Gauge('inactiveFlowsWithIgnores', 'no description in swagger',['applianceName',])
+inactiveFlowsPassthrough = Gauge('inactiveFlowsPassthrough', 'number of inactive passthrough flows',['applianceName',])
+inactiveFlowsManagement = Gauge('inactiveFlowsManagement', 'number of inactive management flows',['applianceName',])
+inactiveFlowsAsymmetric = Gauge('inactiveFlowsAsymmetric', 'number of inactive asymmetric flows',['applianceName',])
+inactiveFlowsRouteDropped = Gauge('inactiveFlowsRouteDropped', 'number of inactive flows dropped due to route',['applianceName',])
+inactiveFlowsFirewallDropped = Gauge('inactiveFlowsFirewallDropped', 'number of inactive flows dropped due to firewall',['applianceName',])

--- a/test/test_vars.yml
+++ b/test/test_vars.yml
@@ -20,8 +20,10 @@ appliances:
    edge-1: # Change name accordingly 
       - {system: true, interval: 120}
       - {bgp: true, interval: 120} 
+      - {flows: true, interval: 120} 
    edge-2: # Change name accordingly 
       - {system: true, interval: 120}
       - {bgp: true, interval: 120}
+      - {flows: true, interval: 120} 
 
 


### PR DESCRIPTION
## Adding Support for flows.

Adding the following metrics

| Name  | Type  | Description  |
| ------------ | ------------ | ------------ |
| activeTotalFlows  | Gauge  | number of active flows  | 
| activeStaleFlows  | Gauge  | number of active stale flows  | 
| activeInconsistentFlows  | Gauge  | number of active inconsistent flows  | 
| activeFlowsWithIssues  | Gauge  | number of active flows with issues  | 
| activeFlowsOptimized  | Gauge  | number of active optimized flows  | 
| activeFlowsWithIgnores  | Gauge  | no description in swagger  | 
| activeFlowsPassthrough  | Gauge  | number of active passthrough flows  | 
| activeFlowsManagement  | Gauge  | number of active management flows  | 
| activeFlowsAsymmetric  | Gauge  | number of active asymmetric flows  | 
| activeFlowsRouteDropped  | Gauge  | number of active flows dropped due to route  | 
| activeFlowsFirewallDropped  | Gauge  | number of active flows dropped due to firewall  | 
| inactiveTotalFlows  | Gauge  | number of inactive flows  | 
| inactiveStaleFlows  | Gauge  | number of inactive stale flows  | 
| inactiveInconsistentFlows  | Gauge  | number of inactive inconsistent flows  | 
| inactiveFlowsWithIssues  | Gauge  | number of inactive flows with issues  | 
| inactiveFlowsOptimized  | Gauge  | number of inactive optimized flows  | 
| inactiveFlowsWithIgnores  | Gauge  | no description in swagger  | 
| inactiveFlowsPassthrough  | Gauge  | number of inactive passthrough flows  | 
| inactiveFlowsManagement  | Gauge  | number of inactive management flows  | 
| inactiveFlowsAsymmetric  | Gauge  | number of inactive asymmetric flows  | 
| inactiveFlowsRouteDropped  | Gauge  | number of inactive flows dropped due to route  | 
| inactiveFlowsFirewallDropped  | Gauge  | number of inactive flows dropped due to firewall  | 